### PR TITLE
Fix sync issue with newly added groups in HISinOne

### DIFF
--- a/Services/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
+++ b/Services/WebServices/ECS/classes/Course/class.ilECSCmsCourseMemberCommandQueueHandler.php
@@ -225,12 +225,12 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
                 // the sequence number in the course ressource
                 $sequence_number = (int) $pgroup->num;
                 // find parallel group with by sequence number
-                $tmp_pgroup = $course->groups[$sequence_number];
+                $tmp_pgroup = $course->groups[$sequence_number] ?? null;
                 if (is_object($tmp_pgroup) && $tmp_pgroup->id !== '') {
                     $this->log->debug('Found parallel group with id: ' . $tmp_pgroup->id . ': for sequence number: ' . $sequence_number);
 
                     // @todo check hierarchy of roles
-                    $assigned[$tmp_pgroup->id][$member->personID] = array(
+                  $assigned[$pgroup->id][$member->personID] = array(
                         'id' => $member->personID,
                         'role' => $pgroup->role
                     );
@@ -459,7 +459,7 @@ class ilECSCmsCourseMemberCommandQueueHandler implements ilECSCommandQueueHandle
      */
     private function readCourse($course_member)
     {
-        $ecs_id = ilECSImportManager::getInstance()->lookupEContentIdByContentId(
+        $ecs_id = ilECSImportManager::getInstance()->lookupLatestEContentIdByContentId(
             $this->getServer()->getServerId(),
             $this->getMid(),
             $course_member->lectureID

--- a/Services/WebServices/ECS/classes/class.ilECSImportManager.php
+++ b/Services/WebServices/ECS/classes/class.ilECSImportManager.php
@@ -121,6 +121,20 @@ class ilECSImportManager
         return 0;
     }
 
+    public function lookupLatestEContentIdByContentId($a_server_id, $a_mid, $a_content_id): int
+    {
+        $query = 'SELECT * from ecs_import ' .
+            'WHERE server_id = ' . $this->db->quote($a_server_id, 'integer') . ' ' .
+            'AND mid = ' . $this->db->quote($a_mid, 'integer') . ' ' .
+            'AND content_id = ' . $this->db->quote($a_content_id, 'text') . ' ' .
+            'ORDER BY econtent_id DESC';
+        $res = $this->db->query($query);
+        if ($row = $res->fetchRow(ilDBConstants::FETCHMODE_OBJECT)) {
+            return (int) $row->econtent_id;
+        }
+        return 0;
+    }
+
     /**
      * get all imported links
      *


### PR DESCRIPTION
Previously, when new groups were added in HISinOne after the first sync to the ECS server, they were created as courses in ILIAS but without participants, and participant lists were mixed up across courses. Thanks to Ilja's fix, the participant mixing issue was resolved. However, the issue with new groups being created without participants persisted.

The root cause was that ILIAS fetched the first available messages from the ECS server, which did not contain the information for the newly added groups. This fix introduces an `ORDER BY econtent_id DESC` in the ECS message fetching process, ensuring that ILIAS retrieves the most recent messages with accurate participant data.

This commit includes Ilja's fix

Note: It is unclear whether this change might affect other ECS-related issues. ￼