### PR TITLE
Handle errors for unmigrated media_objects

### DIFF
--- a/components/ILIAS/MediaObjects/MediaObject/MediaObjectRepository.php
+++ b/components/ILIAS/MediaObjects/MediaObject/MediaObjectRepository.php
@@ -154,7 +154,10 @@ class MediaObjectRepository
 
     public function getLocalSrc(int $mob_id, string $location): string
     {
-        return $this->irss->getContainerUri($this->getRidForMobId($mob_id), $location);
+	if (($this->getRidForMobId($mob_id) && !empty($location))) {
+		return $this->irss->getContainerUri($this->getRidForMobId($mob_id), $location);
+	}
+	return "/dummy/dummy.png" ;
     }
 
     public function hasLocalFile(int $mob_id, string $location): bool

--- a/components/ILIAS/Repository/Service/IRSS/IRSSWrapper.php
+++ b/components/ILIAS/Repository/Service/IRSS/IRSSWrapper.php
@@ -452,6 +452,7 @@ class IRSSWrapper
         string $entry
     ): bool {
         $zip_path = $this->stream($rid)?->getMetadata("uri");
+	if ($zip_path){
         try {
             $stream = Streams::ofFileInsideZIP(
                 $zip_path,
@@ -461,7 +462,9 @@ class IRSSWrapper
             return true;
         } catch (\Exception $e) {
             return false;
-        }
+	    }
+	}
+	return false;
     }
 
 


### PR DESCRIPTION
temporary workaround to keep ILIAS usable while the MediaObject migration is still running.